### PR TITLE
🛡️ Sentinel: [Medium] Add sandbox attribute to third-party iframes

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -215,6 +215,7 @@
                 iframe.allowFullscreen = true;
                 iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
                 iframe.title = '3 Minute Thesis competition video';
+                iframe.sandbox = 'allow-scripts allow-same-origin allow-popups allow-presentation';
 
                 // Clear container and append iframe
                 while (container.firstChild) {

--- a/index.html
+++ b/index.html
@@ -551,7 +551,7 @@
 	<script src="assets/js/bootstrap.min.js?v=2025.11" integrity="sha384-a5jtiYH5jy2C9nk8lKcS1rJKNol+cJ9NJsVMDkCOm9QKXwm5Rq9bpSzg6zmnr48D" defer></script>
 	<script src="assets/plugins/vegas/jquery.vegas.min.js?v=2025.11" integrity="sha384-coBErv0EgCI7VkSd++JmHxhjwxROUhJ37ZNTnevFBMK4ukZOMTiD+wLfguBX205T" defer></script>
 	<script src="assets/js/security-init.js?v=2025.11" integrity="sha384-pErhzH0PSA1f7EnrS4Dfo0t3Y1SM0VRvnHUjbUXVawqrdVB3kTGmRRcNIUJiXCr/" defer></script>
-	<script src="assets/js/main.js?v=2025.12.1" integrity="sha384-0VRup29DOBxGZBMqfpqmKMPUz0kNRDjDS3Res32dR76CBzyXyt5yAyLGwM3Waz2Q" defer></script>
+	<script src="assets/js/main.js?v=2025.12.2" integrity="sha384-LQdxtttNznxc5b18VeZIP1MP3IuO1BWbkMsVDMOn4W+INuDu0XLyhGKILQKsNsiS" defer></script>
 	
 	<!-- Service Worker registration moved to assets/js/security-init.js -->
 	

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Service Worker for Advanced Caching Strategy
-// Version: 2025.12.1
+// Version: 2025.12.2
 
-const CACHE_NAME = 'prajitdas-cache-v2025.12.1';
-const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.1';
-const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.1';
+const CACHE_NAME = 'prajitdas-cache-v2025.12.2';
+const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.2';
+const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.2';
 
 // Critical resources for immediate caching (LCP optimization)
 const CRITICAL_ASSETS = [
@@ -23,7 +23,7 @@ const STATIC_ASSETS = [
   '/assets/js/jquery-3.7.1.min.js?v=2025.11',
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
-  '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/main.js?v=2025.12.2',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Third-party iframes (like the dynamically loaded YouTube player) lacked a `sandbox` attribute. Without this, embedded content runs with fewer restrictions, increasing the risk of frame-jacking or executing unwanted top-level navigation, even if the source is trusted.
🎯 **Impact:** Prevents embedded third-party content from unexpectedly modifying the parent page, executing plugins, or performing top-level navigation, thereby enforcing the principle of least privilege.
🔧 **Fix:**
- Added `sandbox="allow-scripts allow-same-origin allow-popups allow-presentation"` to the YouTube iframe creation logic in `assets/js/main.js`.
- Incremented `main.js` version parameter to `v2025.12.2` in `index.html` and `sw.js`.
- Incremented cache constants in `sw.js` to force cache invalidation.
- Generated and updated the new SHA-384 Subresource Integrity (SRI) hash for `main.js` within `index.html`.
✅ **Verification:** Verified that the iframe renders successfully with the `sandbox` attribute. Verified that the website tests and validation suite completed successfully with no regression on SRI loading errors.

---
*PR created automatically by Jules for task [3812472127572605177](https://jules.google.com/task/3812472127572605177) started by @prajitdas*