### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSP unsafe-inline vulnerability in script-src

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -75,7 +75,7 @@
   Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
   Header always set Referrer-Policy "strict-origin-when-cross-origin"
   Header always set Permissions-Policy "camera=(), microphone=(), geolocation=()"
-  Header always set Content-Security-Policy "default-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; media-src 'self' https:; object-src 'none'; frame-src 'self' https://www.youtube.com https://youtube.com; base-uri 'self'; form-action 'self';"
+  Header always set Content-Security-Policy "default-src 'self' https:; script-src 'self' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; media-src 'self' https:; object-src 'none'; frame-src 'self' https://www.youtube.com https://youtube.com; base-uri 'self'; form-action 'self';"
 </IfModule>
 
 <IfModule mod_gzip.c>

--- a/404.html
+++ b/404.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/assets/js/modern.js
+++ b/assets/js/modern.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', function() {
+            const btn = document.getElementById('read-more-btn');
+            const moreContent = document.getElementById('about-more');
+
+            if (btn && moreContent) {
+                btn.addEventListener('click', function() {
+                    if (moreContent.classList.contains('visible')) {
+                        moreContent.classList.remove('visible');
+                        btn.innerHTML = 'Read More <i class="fas fa-chevron-down"></i>';
+                    } else {
+                        moreContent.classList.add('visible');
+                        btn.innerHTML = 'Read Less <i class="fas fa-chevron-up"></i>';
+                    }
+                });
+            }
+
+            // Email obfuscation
+            const emailLink = document.getElementById('email-link');
+            if (emailLink) {
+                const user = 'prajitdas';
+                const domain = 'gmail.com';
+                emailLink.addEventListener('mouseover', function() {
+                    this.href = 'mailto:' + user + '@' + domain;
+                });
+                emailLink.addEventListener('click', function(e) {
+                    if (this.getAttribute('href') === '#') {
+                        e.preventDefault();
+                        window.location.href = 'mailto:' + user + '@' + domain;
+                    }
+                });
+            }
+        });

--- a/experience.html
+++ b/experience.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/modern.html
+++ b/modern.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->
@@ -136,40 +136,7 @@
             <p>&copy; 2025 Prajit Kumar Das. Hosted on GitHub Pages.</p>
         </div>
     </footer>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const btn = document.getElementById('read-more-btn');
-            const moreContent = document.getElementById('about-more');
-            
-            if (btn && moreContent) {
-                btn.addEventListener('click', function() {
-                    if (moreContent.classList.contains('visible')) {
-                        moreContent.classList.remove('visible');
-                        btn.innerHTML = 'Read More <i class="fas fa-chevron-down"></i>';
-                    } else {
-                        moreContent.classList.add('visible');
-                        btn.innerHTML = 'Read Less <i class="fas fa-chevron-up"></i>';
-                    }
-                });
-            }
-
-            // Email obfuscation
-            const emailLink = document.getElementById('email-link');
-            if (emailLink) {
-                const user = 'prajitdas';
-                const domain = 'gmail.com';
-                emailLink.addEventListener('mouseover', function() {
-                    this.href = 'mailto:' + user + '@' + domain;
-                });
-                emailLink.addEventListener('click', function(e) {
-                    if (this.getAttribute('href') === '#') {
-                        e.preventDefault();
-                        window.location.href = 'mailto:' + user + '@' + domain;
-                    }
-                });
-            }
-        });
-    </script>
+    <script src="assets/js/modern.js"></script>
     <script src="assets/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/publications.html
+++ b/publications.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/service.html
+++ b/service.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix CSP unsafe-inline vulnerability in script-src

🚨 Severity: HIGH
💡 Vulnerability: The Content-Security-Policy (CSP) allowed `'unsafe-inline'` in the `script-src` directive across all HTML pages and the `.htaccess` configuration. This significantly weakened the CSP, leaving the site vulnerable to Cross-Site Scripting (XSS) attacks.
🎯 Impact: An attacker could potentially inject and execute arbitrary JavaScript, bypassing the CSP's protection mechanism.
🔧 Fix: 
  - Extracted the inline script block from `modern.html` to a new external file `assets/js/modern.js` and referenced it via `<script src="assets/js/modern.js"></script>`.
  - Removed `'unsafe-inline'` from the `script-src` directive in the CSP meta tags of all sub-pages (`projects.html`, `publications.html`, `service.html`, `modern.html`, `404.html`, `experience.html`).
  - Hardened the CSP rules in `.htaccess` by properly separating `default-src` (removed `unsafe-inline`) and `script-src` (disallowed inline), while preserving `unsafe-inline` strictly in `style-src` as required by the site.
✅ Verification: Ran the comprehensive validation test suite (`python3 .github/code/tests/run_all_validation.py --quick`), which passed all checks including the `content_security_privacy` validation. Visually verified the extracted script functionally works and pages render correctly via Playwright screenshots.

---
*PR created automatically by Jules for task [11636225956161215150](https://jules.google.com/task/11636225956161215150) started by @prajitdas*