### PR TITLE
🛡️ Sentinel: [MEDIUM] Add sandbox attribute to isolate third-party iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** The `404.html` page had a weaker Content Security Policy (CSP) allowing `'unsafe-inline'` and lacked the essential security initialization script (`assets/js/security-init.js`) found in `index.html`. This created a potential attack vector if an attacker could lure a user to a non-existent URL.
 **Learning:** Security configurations (CSP, SRI, Headers) must be consistent across all pages, including error pages (404, 500). Error pages are often overlooked during security audits but share the same origin and can be exploited.
 **Prevention:** Treat `404.html` as a first-class citizen in the security architecture. Ensure it imports the same security-hardened scripts and uses the same strict CSP headers as the main application. Verify error pages during security testing.
+
+## 2025-02-24 - [Isolate Third-Party Iframes]
+**Vulnerability:** Dynamically loaded YouTube video iframes lacked the `sandbox` attribute, allowing the third-party embedded content unnecessary privileges within the application's context.
+**Learning:** Third-party iframes, especially those dynamically injected via JavaScript, must always use the `sandbox` attribute to enforce strict privilege boundaries. Crucially, `allow-same-origin` should be omitted to prevent the iframe from accessing the parent document's DOM, cookies, or storage.
+**Prevention:** Apply `sandbox="allow-scripts allow-popups allow-presentation"` (or similar restricted set) to all `<iframe>` elements to mitigate the risk of malicious or compromised third-party content executing unauthorized actions.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -215,6 +215,7 @@
                 iframe.allowFullscreen = true;
                 iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
                 iframe.title = '3 Minute Thesis competition video';
+                iframe.sandbox = 'allow-scripts allow-popups allow-presentation';
 
                 // Clear container and append iframe
                 while (container.firstChild) {

--- a/index.html
+++ b/index.html
@@ -551,7 +551,7 @@
 	<script src="assets/js/bootstrap.min.js?v=2025.11" integrity="sha384-a5jtiYH5jy2C9nk8lKcS1rJKNol+cJ9NJsVMDkCOm9QKXwm5Rq9bpSzg6zmnr48D" defer></script>
 	<script src="assets/plugins/vegas/jquery.vegas.min.js?v=2025.11" integrity="sha384-coBErv0EgCI7VkSd++JmHxhjwxROUhJ37ZNTnevFBMK4ukZOMTiD+wLfguBX205T" defer></script>
 	<script src="assets/js/security-init.js?v=2025.11" integrity="sha384-pErhzH0PSA1f7EnrS4Dfo0t3Y1SM0VRvnHUjbUXVawqrdVB3kTGmRRcNIUJiXCr/" defer></script>
-	<script src="assets/js/main.js?v=2025.12.1" integrity="sha384-0VRup29DOBxGZBMqfpqmKMPUz0kNRDjDS3Res32dR76CBzyXyt5yAyLGwM3Waz2Q" defer></script>
+	<script src="assets/js/main.js?v=2025.12.2" integrity="sha384-9VD0JdFq7AkBYC6e4AatjipIl5ZLdxB/enFzbOcC0QWoQNoW9jzraY5aPh21v5vy" defer></script>
 	
 	<!-- Service Worker registration moved to assets/js/security-init.js -->
 	

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Service Worker for Advanced Caching Strategy
-// Version: 2025.12.1
+// Version: 2025.12.2
 
-const CACHE_NAME = 'prajitdas-cache-v2025.12.1';
-const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.1';
-const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.1';
+const CACHE_NAME = 'prajitdas-cache-v2025.12.2';
+const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.2';
+const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.2';
 
 // Critical resources for immediate caching (LCP optimization)
 const CRITICAL_ASSETS = [
@@ -23,7 +23,7 @@ const STATIC_ASSETS = [
   '/assets/js/jquery-3.7.1.min.js?v=2025.11',
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
-  '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/main.js?v=2025.12.2',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Dynamically loaded YouTube video iframes lacked the `sandbox` attribute, allowing third-party embedded content unnecessary privileges within the application's context.
🎯 Impact: This could potentially allow the embedded content to execute unauthorized actions, access parent frame resources, or manipulate the parent DOM if the third-party source is compromised.
🔧 Fix: Applied `sandbox="allow-scripts allow-popups allow-presentation"` to the iframe element to enforce strict privilege boundaries and mitigate risk.
✅ Verification: Ensure the `run_all_validation.py` script passes successfully and no regressions are introduced.

---
*PR created automatically by Jules for task [8949297972690213691](https://jules.google.com/task/8949297972690213691) started by @prajitdas*