### PR TITLE
🛡️ Sentinel: [HIGH] Remove unsafe-inline from CSP and externalize inline script

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -75,7 +75,7 @@
   Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
   Header always set Referrer-Policy "strict-origin-when-cross-origin"
   Header always set Permissions-Policy "camera=(), microphone=(), geolocation=()"
-  Header always set Content-Security-Policy "default-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; media-src 'self' https:; object-src 'none'; frame-src 'self' https://www.youtube.com https://youtube.com; base-uri 'self'; form-action 'self';"
+  Header always set Content-Security-Policy "default-src 'self' https:; script-src 'self' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; media-src 'self' https:; object-src 'none'; frame-src 'self' https://www.youtube.com https://youtube.com; base-uri 'self'; form-action 'self';"
 </IfModule>
 
 <IfModule mod_gzip.c>

--- a/404.html
+++ b/404.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/assets/js/modern.js
+++ b/assets/js/modern.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const btn = document.getElementById('read-more-btn');
+    const moreContent = document.getElementById('about-more');
+
+    if (btn && moreContent) {
+        btn.addEventListener('click', function() {
+            if (moreContent.classList.contains('visible')) {
+                moreContent.classList.remove('visible');
+                btn.innerHTML = 'Read More <i class="fas fa-chevron-down"></i>';
+            } else {
+                moreContent.classList.add('visible');
+                btn.innerHTML = 'Read Less <i class="fas fa-chevron-up"></i>';
+            }
+        });
+    }
+
+    // Email obfuscation
+    const emailLink = document.getElementById('email-link');
+    if (emailLink) {
+        const user = 'prajitdas';
+        const domain = 'gmail.com';
+        emailLink.addEventListener('mouseover', function() {
+            this.href = 'mailto:' + user + '@' + domain;
+        });
+        emailLink.addEventListener('click', function(e) {
+            if (this.getAttribute('href') === '#') {
+                e.preventDefault();
+                window.location.href = 'mailto:' + user + '@' + domain;
+            }
+        });
+    }
+});

--- a/experience.html
+++ b/experience.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/modern.html
+++ b/modern.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->
@@ -136,40 +136,7 @@
             <p>&copy; 2025 Prajit Kumar Das. Hosted on GitHub Pages.</p>
         </div>
     </footer>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const btn = document.getElementById('read-more-btn');
-            const moreContent = document.getElementById('about-more');
-            
-            if (btn && moreContent) {
-                btn.addEventListener('click', function() {
-                    if (moreContent.classList.contains('visible')) {
-                        moreContent.classList.remove('visible');
-                        btn.innerHTML = 'Read More <i class="fas fa-chevron-down"></i>';
-                    } else {
-                        moreContent.classList.add('visible');
-                        btn.innerHTML = 'Read Less <i class="fas fa-chevron-up"></i>';
-                    }
-                });
-            }
-
-            // Email obfuscation
-            const emailLink = document.getElementById('email-link');
-            if (emailLink) {
-                const user = 'prajitdas';
-                const domain = 'gmail.com';
-                emailLink.addEventListener('mouseover', function() {
-                    this.href = 'mailto:' + user + '@' + domain;
-                });
-                emailLink.addEventListener('click', function(e) {
-                    if (this.getAttribute('href') === '#') {
-                        e.preventDefault();
-                        window.location.href = 'mailto:' + user + '@' + domain;
-                    }
-                });
-            }
-        });
-    </script>
+    <script src="assets/js/modern.js?v=2025.12.2" integrity="sha384-BQ8eguuDwTIKEWoIADmXR/l30IuT71KNSdmkTLIdHOkZp9Ty5ZrOfpZyGcB80DM0" defer></script>
     <script src="assets/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/publications.html
+++ b/publications.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/service.html
+++ b/service.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Service Worker for Advanced Caching Strategy
-// Version: 2025.12.1
+// Version: 2025.12.2
 
-const CACHE_NAME = 'prajitdas-cache-v2025.12.1';
-const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.1';
-const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.1';
+const CACHE_NAME = 'prajitdas-cache-v2025.12.2';
+const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.2';
+const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.2';
 
 // Critical resources for immediate caching (LCP optimization)
 const CRITICAL_ASSETS = [
@@ -24,6 +24,7 @@ const STATIC_ASSETS = [
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
   '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/modern.js?v=2025.12.2',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Content Security Policy (CSP) allowed `'unsafe-inline'` in `script-src` and `default-src` across multiple HTML files and `.htaccess`. This significantly increases the risk of Cross-Site Scripting (XSS) attacks, as it permits the execution of arbitrary inline scripts injected by an attacker. Additionally, `modern.html` relied on an inline script for its core functionality.
🎯 **Impact:** If exploited, an attacker could execute malicious JavaScript within the user's browser, potentially leading to session hijacking, data theft, or defacement of the application.
🔧 **Fix:** 
1. Externalized the inline script from `modern.html` to a new file `assets/js/modern.js` and included it with an SRI hash and the `defer` attribute.
2. Removed `'unsafe-inline'` from the `script-src` and `default-src` directives in the `<meta>` CSP headers of all HTML pages (`modern.html`, `404.html`, `experience.html`, `projects.html`, `publications.html`, `service.html`).
3. Updated the `.htaccess` CSP header to remove `'unsafe-inline'` from `default-src` while explicitly adding `style-src 'self' 'unsafe-inline' https:;` to prevent breaking existing CSS functionality, and added `script-src 'self' https:;`.
4. Added `assets/js/modern.js` to the Service Worker (`sw.js`) cache list and incremented the cache versions.
✅ **Verification:** Verified the fix by running the comprehensive test suite (`run_all_validation.py`), ensuring that all security, functionality, and performance validations passed without the presence of inline scripts and with the tightened CSP.

---
*PR created automatically by Jules for task [14365369878681909044](https://jules.google.com/task/14365369878681909044) started by @prajitdas*