### PR TITLE
🛡️ Sentinel: [MEDIUM] Add sandbox attribute to third-party iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** The `404.html` page had a weaker Content Security Policy (CSP) allowing `'unsafe-inline'` and lacked the essential security initialization script (`assets/js/security-init.js`) found in `index.html`. This created a potential attack vector if an attacker could lure a user to a non-existent URL.
 **Learning:** Security configurations (CSP, SRI, Headers) must be consistent across all pages, including error pages (404, 500). Error pages are often overlooked during security audits but share the same origin and can be exploited.
 **Prevention:** Treat `404.html` as a first-class citizen in the security architecture. Ensure it imports the same security-hardened scripts and uses the same strict CSP headers as the main application. Verify error pages during security testing.
+
+## 2026-04-17 - [Third-Party Iframe Privilege Restriction]
+**Vulnerability:** A dynamically created iframe for embedding YouTube videos in `assets/js/main.js` lacked the `sandbox` attribute, potentially exposing the main page to risks if the third-party content was compromised.
+**Learning:** Dynamically created third-party iframes must include a `sandbox` attribute to restrict privileges. For YouTube embeds, `allow-same-origin` is necessary alongside `allow-scripts`, `allow-popups`, and `allow-presentation` for the player to function correctly while still maintaining a restricted environment.
+**Prevention:** Always apply the `sandbox` attribute with the principle of least privilege when embedding third-party content via iframes, even when generated dynamically in JavaScript.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -72,8 +72,6 @@
             var $link = e(this);
             var rel = $link.attr('rel') || '';
 
-            // Ensure security attributes are present
-            var rel = $link.attr('rel') || '';
             // Add noopener if missing
             if (rel.indexOf('noopener') === -1) {
                 rel += (rel ? ' ' : '') + 'noopener';
@@ -215,6 +213,7 @@
                 iframe.allowFullscreen = true;
                 iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
                 iframe.title = '3 Minute Thesis competition video';
+                iframe.setAttribute('sandbox', 'allow-scripts allow-popups allow-presentation allow-same-origin');
 
                 // Clear container and append iframe
                 while (container.firstChild) {

--- a/index.html
+++ b/index.html
@@ -551,7 +551,7 @@
 	<script src="assets/js/bootstrap.min.js?v=2025.11" integrity="sha384-a5jtiYH5jy2C9nk8lKcS1rJKNol+cJ9NJsVMDkCOm9QKXwm5Rq9bpSzg6zmnr48D" defer></script>
 	<script src="assets/plugins/vegas/jquery.vegas.min.js?v=2025.11" integrity="sha384-coBErv0EgCI7VkSd++JmHxhjwxROUhJ37ZNTnevFBMK4ukZOMTiD+wLfguBX205T" defer></script>
 	<script src="assets/js/security-init.js?v=2025.11" integrity="sha384-pErhzH0PSA1f7EnrS4Dfo0t3Y1SM0VRvnHUjbUXVawqrdVB3kTGmRRcNIUJiXCr/" defer></script>
-	<script src="assets/js/main.js?v=2025.12.1" integrity="sha384-0VRup29DOBxGZBMqfpqmKMPUz0kNRDjDS3Res32dR76CBzyXyt5yAyLGwM3Waz2Q" defer></script>
+	<script src="assets/js/main.js?v=2025.12.2" integrity="sha384-Ipy1u/i8bvMSc0oDqOEz5iXtYc+42csJhU7tdC/d4SWnH7yJ9XMSi8qTSwiW6lFJ" defer></script>
 	
 	<!-- Service Worker registration moved to assets/js/security-init.js -->
 	

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Service Worker for Advanced Caching Strategy
-// Version: 2025.12.1
+// Version: 2025.12.2
 
-const CACHE_NAME = 'prajitdas-cache-v2025.12.1';
-const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.1';
-const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.1';
+const CACHE_NAME = 'prajitdas-cache-v2025.12.2';
+const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.2';
+const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.2';
 
 // Critical resources for immediate caching (LCP optimization)
 const CRITICAL_ASSETS = [
@@ -23,7 +23,7 @@ const STATIC_ASSETS = [
   '/assets/js/jquery-3.7.1.min.js?v=2025.11',
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
-  '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/main.js?v=2025.12.2',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** A dynamically created iframe for embedding YouTube videos in `assets/js/main.js` lacked the `sandbox` attribute, potentially exposing the main page to risks if the third-party content was compromised.
**🎯 Impact:** Without a sandbox, embedded third-party content has broader privileges than necessary. If the third-party source is compromised or serves malicious content, it could potentially execute scripts or perform actions that affect the parent frame.
**🔧 Fix:** Added `iframe.setAttribute('sandbox', 'allow-scripts allow-popups allow-presentation allow-same-origin');` to the iframe creation logic in `assets/js/main.js`. This restricts the iframe while allowing necessary features for the YouTube player to function correctly. Also removed a duplicate `var rel = $link.attr('rel') || '';` declaration to fix a JSHint warning. Generated a new SRI hash and bumped the version to `v2025.12.2` in `index.html` and `sw.js`.
**✅ Verification:** Ran the local test suite using `python3 .github/code/tests/run_all_validation.py --quick`, and all JS syntax, integrity, and security validations passed. Reviewed code to ensure the fix was applied properly and dependencies were updated. Included a new Sentinel Journal entry.

---
*PR created automatically by Jules for task [17357660409124911320](https://jules.google.com/task/17357660409124911320) started by @prajitdas*