### PR TITLE
🛡️ Sentinel: [MEDIUM] Add sandbox attribute to third-party iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** The `404.html` page had a weaker Content Security Policy (CSP) allowing `'unsafe-inline'` and lacked the essential security initialization script (`assets/js/security-init.js`) found in `index.html`. This created a potential attack vector if an attacker could lure a user to a non-existent URL.
 **Learning:** Security configurations (CSP, SRI, Headers) must be consistent across all pages, including error pages (404, 500). Error pages are often overlooked during security audits but share the same origin and can be exploited.
 **Prevention:** Treat `404.html` as a first-class citizen in the security architecture. Ensure it imports the same security-hardened scripts and uses the same strict CSP headers as the main application. Verify error pages during security testing.
+
+## 2025-02-24 - [Third-Party Iframe Sandbox Protection]
+**Vulnerability:** Dynamically created third-party iframes (specifically the YouTube embed in `assets/js/main.js`) lacked the `sandbox` attribute, violating the principle of least privilege. This could allow an embedded page to execute malicious scripts or navigate the top-level window.
+**Learning:** Third-party embeds must always include a `sandbox` attribute to restrict their capabilities. For YouTube embeds, `allow-same-origin` is required for the player to function properly, along with `allow-scripts`, `allow-popups`, and `allow-presentation`.
+**Prevention:** When dynamically creating or embedding third-party content via iframes, always enforce strict `sandbox` policies by default, relaxing them only as explicitly required for functionality.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -73,7 +73,6 @@
             var rel = $link.attr('rel') || '';
 
             // Ensure security attributes are present
-            var rel = $link.attr('rel') || '';
             // Add noopener if missing
             if (rel.indexOf('noopener') === -1) {
                 rel += (rel ? ' ' : '') + 'noopener';
@@ -214,6 +213,7 @@
                 iframe.frameBorder = '0';
                 iframe.allowFullscreen = true;
                 iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+                iframe.sandbox = 'allow-scripts allow-popups allow-presentation allow-same-origin';
                 iframe.title = '3 Minute Thesis competition video';
 
                 // Clear container and append iframe

--- a/index.html
+++ b/index.html
@@ -551,7 +551,7 @@
 	<script src="assets/js/bootstrap.min.js?v=2025.11" integrity="sha384-a5jtiYH5jy2C9nk8lKcS1rJKNol+cJ9NJsVMDkCOm9QKXwm5Rq9bpSzg6zmnr48D" defer></script>
 	<script src="assets/plugins/vegas/jquery.vegas.min.js?v=2025.11" integrity="sha384-coBErv0EgCI7VkSd++JmHxhjwxROUhJ37ZNTnevFBMK4ukZOMTiD+wLfguBX205T" defer></script>
 	<script src="assets/js/security-init.js?v=2025.11" integrity="sha384-pErhzH0PSA1f7EnrS4Dfo0t3Y1SM0VRvnHUjbUXVawqrdVB3kTGmRRcNIUJiXCr/" defer></script>
-	<script src="assets/js/main.js?v=2025.12.1" integrity="sha384-0VRup29DOBxGZBMqfpqmKMPUz0kNRDjDS3Res32dR76CBzyXyt5yAyLGwM3Waz2Q" defer></script>
+	<script src="assets/js/main.js?v=2025.12.2" integrity="sha384-wPQFvyyOjjdp7HEBV2H65rJ/EzIE6vh340DGXSMDfA3Z9E3wkfoj+Ys1r0BG3Lkw" defer></script>
 	
 	<!-- Service Worker registration moved to assets/js/security-init.js -->
 	

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Service Worker for Advanced Caching Strategy
-// Version: 2025.12.1
+// Version: 2025.12.2
 
-const CACHE_NAME = 'prajitdas-cache-v2025.12.1';
-const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.1';
-const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.1';
+const CACHE_NAME = 'prajitdas-cache-v2025.12.2';
+const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.2';
+const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.2';
 
 // Critical resources for immediate caching (LCP optimization)
 const CRITICAL_ASSETS = [
@@ -23,7 +23,7 @@ const STATIC_ASSETS = [
   '/assets/js/jquery-3.7.1.min.js?v=2025.11',
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
-  '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/main.js?v=2025.12.2',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Dynamically created third-party iframes for YouTube embeds lacked the `sandbox` attribute, violating the principle of least privilege and allowing potential execution of malicious scripts or top-level navigation.
🎯 Impact: An embedded page could theoretically navigate the user away or execute malicious actions.
🔧 Fix: Added `iframe.sandbox = 'allow-scripts allow-popups allow-presentation allow-same-origin';` to restrict capabilities while maintaining YouTube functionality. Removed redundant variable declaration in `assets/js/main.js`. Updated SRI hashes and versions.
✅ Verification: Ran full website validation test suite successfully. Verified updated SRI hashes in `index.html` and version bumps in `sw.js`.

---
*PR created automatically by Jules for task [14819650878005098075](https://jules.google.com/task/14819650878005098075) started by @prajitdas*