### PR TITLE
🛡️ Sentinel: [Medium] Add sandbox restrictions to third-party iframes

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -215,6 +215,8 @@
                 iframe.allowFullscreen = true;
                 iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
                 iframe.title = '3 Minute Thesis competition video';
+                // 🛡️ Sentinel: Restrict third-party iframe privileges using sandbox
+                iframe.sandbox = 'allow-scripts allow-popups allow-presentation allow-same-origin';
 
                 // Clear container and append iframe
                 while (container.firstChild) {

--- a/index.html
+++ b/index.html
@@ -551,7 +551,7 @@
 	<script src="assets/js/bootstrap.min.js?v=2025.11" integrity="sha384-a5jtiYH5jy2C9nk8lKcS1rJKNol+cJ9NJsVMDkCOm9QKXwm5Rq9bpSzg6zmnr48D" defer></script>
 	<script src="assets/plugins/vegas/jquery.vegas.min.js?v=2025.11" integrity="sha384-coBErv0EgCI7VkSd++JmHxhjwxROUhJ37ZNTnevFBMK4ukZOMTiD+wLfguBX205T" defer></script>
 	<script src="assets/js/security-init.js?v=2025.11" integrity="sha384-pErhzH0PSA1f7EnrS4Dfo0t3Y1SM0VRvnHUjbUXVawqrdVB3kTGmRRcNIUJiXCr/" defer></script>
-	<script src="assets/js/main.js?v=2025.12.1" integrity="sha384-0VRup29DOBxGZBMqfpqmKMPUz0kNRDjDS3Res32dR76CBzyXyt5yAyLGwM3Waz2Q" defer></script>
+	<script src="assets/js/main.js?v=2025.12.2" integrity="sha384-F7k9x9BL/xKZhKrJQplICmZ5VvvbAkwE0y88phCCy4SfUi0Hn6zDcMaykPaKCGhV" defer></script>
 	
 	<!-- Service Worker registration moved to assets/js/security-init.js -->
 	

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Service Worker for Advanced Caching Strategy
-// Version: 2025.12.1
+// Version: 2025.12.2
 
-const CACHE_NAME = 'prajitdas-cache-v2025.12.1';
-const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.1';
-const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.1';
+const CACHE_NAME = 'prajitdas-cache-v2025.12.2';
+const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.2';
+const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.2';
 
 // Critical resources for immediate caching (LCP optimization)
 const CRITICAL_ASSETS = [
@@ -23,7 +23,7 @@ const STATIC_ASSETS = [
   '/assets/js/jquery-3.7.1.min.js?v=2025.11',
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
-  '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/main.js?v=2025.12.2',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Dynamically generated third-party iframes (e.g., YouTube video player) lack the `sandbox` attribute, allowing them full privileges over the page. While YouTube is trusted, this is a bad security practice and lacks defense-in-depth.
🎯 Impact: If a third-party iframe domain is compromised or acts maliciously, it could execute arbitrary scripts, open popups, or perform other unwanted actions with the same privileges as the parent document.
🔧 Fix: Added the `sandbox="allow-scripts allow-popups allow-presentation allow-same-origin"` attribute to the dynamically generated iframe in `assets/js/main.js` to restrict its capabilities while still allowing necessary functionalities. Updated versions in `sw.js` and `index.html`, and recalculated the SRI hash for `main.js`.
✅ Verification: Ran the validation suite locally to ensure no functional errors were introduced. Checked the code manually to verify the `sandbox` attribute is applied before appending the iframe.

---
*PR created automatically by Jules for task [3838737664251146311](https://jules.google.com/task/3838737664251146311) started by @prajitdas*