### PR TITLE
🛡️ Sentinel: [Medium] Add sandbox attribute to third-party iframes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** The `404.html` page had a weaker Content Security Policy (CSP) allowing `'unsafe-inline'` and lacked the essential security initialization script (`assets/js/security-init.js`) found in `index.html`. This created a potential attack vector if an attacker could lure a user to a non-existent URL.
 **Learning:** Security configurations (CSP, SRI, Headers) must be consistent across all pages, including error pages (404, 500). Error pages are often overlooked during security audits but share the same origin and can be exploited.
 **Prevention:** Treat `404.html` as a first-class citizen in the security architecture. Ensure it imports the same security-hardened scripts and uses the same strict CSP headers as the main application. Verify error pages during security testing.
+
+## 2025-02-24 - [Medium - Third-Party Iframe Sandboxing]
+**Vulnerability:** Third-party iframes (e.g., YouTube embeds in `assets/js/main.js`) were missing the `sandbox` attribute, potentially exposing the application to exploits if the embedded content is compromised (e.g., executing malicious scripts, accessing the parent context).
+**Learning:** Even when embedding trusted third-party content, the principle of least privilege should be applied. The `sandbox` attribute restricts iframe capabilities. For YouTube, `allow-scripts allow-popups allow-presentation allow-same-origin` is required for functionality but still limits other risky behaviors.
+**Prevention:** Always include a strictly configured `sandbox` attribute when dynamically or statically creating third-party iframes to restrict their privileges and protect the parent application.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -215,6 +215,8 @@
                 iframe.allowFullscreen = true;
                 iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
                 iframe.title = '3 Minute Thesis competition video';
+                // 🛡️ Sentinel: Enforce strict sandboxing on third-party iframe
+                iframe.sandbox = 'allow-scripts allow-popups allow-presentation allow-same-origin';
 
                 // Clear container and append iframe
                 while (container.firstChild) {

--- a/index.html
+++ b/index.html
@@ -551,7 +551,7 @@
 	<script src="assets/js/bootstrap.min.js?v=2025.11" integrity="sha384-a5jtiYH5jy2C9nk8lKcS1rJKNol+cJ9NJsVMDkCOm9QKXwm5Rq9bpSzg6zmnr48D" defer></script>
 	<script src="assets/plugins/vegas/jquery.vegas.min.js?v=2025.11" integrity="sha384-coBErv0EgCI7VkSd++JmHxhjwxROUhJ37ZNTnevFBMK4ukZOMTiD+wLfguBX205T" defer></script>
 	<script src="assets/js/security-init.js?v=2025.11" integrity="sha384-pErhzH0PSA1f7EnrS4Dfo0t3Y1SM0VRvnHUjbUXVawqrdVB3kTGmRRcNIUJiXCr/" defer></script>
-	<script src="assets/js/main.js?v=2025.12.1" integrity="sha384-0VRup29DOBxGZBMqfpqmKMPUz0kNRDjDS3Res32dR76CBzyXyt5yAyLGwM3Waz2Q" defer></script>
+	<script src="assets/js/main.js?v=2025.12.2" integrity="sha384-JaCHYuOS/bf1PJ1WkVE4j7l4AdWMow0ac0r9oQ0+2kvREwfp8BuG3ZL4uG8xzUa5" defer></script>
 	
 	<!-- Service Worker registration moved to assets/js/security-init.js -->
 	

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Service Worker for Advanced Caching Strategy
-// Version: 2025.12.1
+// Version: 2025.12.2
 
-const CACHE_NAME = 'prajitdas-cache-v2025.12.1';
-const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.1';
-const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.1';
+const CACHE_NAME = 'prajitdas-cache-v2025.12.2';
+const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.2';
+const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.2';
 
 // Critical resources for immediate caching (LCP optimization)
 const CRITICAL_ASSETS = [
@@ -23,7 +23,7 @@ const STATIC_ASSETS = [
   '/assets/js/jquery-3.7.1.min.js?v=2025.11',
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
-  '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/main.js?v=2025.12.2',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Third-party iframes (e.g., YouTube embeds) were missing the `sandbox` attribute. This could expose the application to potential exploits if the embedded third-party content is compromised, allowing it to execute malicious scripts or access the parent context.
🎯 Impact: An attacker compromising the third-party iframe content could potentially execute malicious actions within the context of our application or navigate the top-level window.
🔧 Fix: Added the `sandbox="allow-scripts allow-popups allow-presentation allow-same-origin"` attribute to the dynamically generated YouTube iframe in `assets/js/main.js`. This follows the principle of least privilege by restricting the iframe's capabilities while still allowing it to function correctly. Also updated the SRI hash in `index.html` and busted the Service Worker cache in `sw.js`.
✅ Verification: Ensure YouTube videos still load and play correctly. Verify that the generated iframe has the `sandbox` attribute present. Check the console for any SRI or CSP errors. Run `python3 .github/code/tests/run_all_validation.py --quick`.

---
*PR created automatically by Jules for task [5440806992342595130](https://jules.google.com/task/5440806992342595130) started by @prajitdas*