### PR TITLE
🛡️ Sentinel: [HIGH] Enforce iframe sandboxing for third-party embeds

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** The `404.html` page had a weaker Content Security Policy (CSP) allowing `'unsafe-inline'` and lacked the essential security initialization script (`assets/js/security-init.js`) found in `index.html`. This created a potential attack vector if an attacker could lure a user to a non-existent URL.
 **Learning:** Security configurations (CSP, SRI, Headers) must be consistent across all pages, including error pages (404, 500). Error pages are often overlooked during security audits but share the same origin and can be exploited.
 **Prevention:** Treat `404.html` as a first-class citizen in the security architecture. Ensure it imports the same security-hardened scripts and uses the same strict CSP headers as the main application. Verify error pages during security testing.
+
+## 2025-05-05 - [Iframe Sandboxing for Third-Party Embeds]
+**Vulnerability:** Dynamically created iframes (like the YouTube video embed) lacked the `sandbox` attribute, potentially exposing the application to cross-site scripting (XSS), malicious popups, and other attacks originating from the third-party content.
+**Learning:** Even trusted third-party providers can be compromised or serve malicious ads. Any third-party content embedded via iframes must be strictly sandboxed to minimize the attack surface. For YouTube specifically, `allow-same-origin` is required alongside basic script permissions to function.
+**Prevention:** Always include the `sandbox` attribute when creating iframes. Apply the principle of least privilege, granting only the specific permissions (`allow-scripts`, `allow-popups`, etc.) necessary for the embed to function.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -214,6 +214,10 @@
                 iframe.frameBorder = '0';
                 iframe.allowFullscreen = true;
                 iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+
+                // 🛡️ Sentinel: Enforce strict sandboxing for third-party embeds
+                // allow-same-origin is required for YouTube player functionality
+                iframe.sandbox = 'allow-scripts allow-popups allow-presentation allow-same-origin';
                 iframe.title = '3 Minute Thesis competition video';
 
                 // Clear container and append iframe

--- a/index.html
+++ b/index.html
@@ -551,7 +551,7 @@
 	<script src="assets/js/bootstrap.min.js?v=2025.11" integrity="sha384-a5jtiYH5jy2C9nk8lKcS1rJKNol+cJ9NJsVMDkCOm9QKXwm5Rq9bpSzg6zmnr48D" defer></script>
 	<script src="assets/plugins/vegas/jquery.vegas.min.js?v=2025.11" integrity="sha384-coBErv0EgCI7VkSd++JmHxhjwxROUhJ37ZNTnevFBMK4ukZOMTiD+wLfguBX205T" defer></script>
 	<script src="assets/js/security-init.js?v=2025.11" integrity="sha384-pErhzH0PSA1f7EnrS4Dfo0t3Y1SM0VRvnHUjbUXVawqrdVB3kTGmRRcNIUJiXCr/" defer></script>
-	<script src="assets/js/main.js?v=2025.12.1" integrity="sha384-0VRup29DOBxGZBMqfpqmKMPUz0kNRDjDS3Res32dR76CBzyXyt5yAyLGwM3Waz2Q" defer></script>
+	<script src="assets/js/main.js?v=2025.12.2" integrity="sha384-BUiedKPj8FAoXlzS8TxUymqfEOU5OUpnalaZCQ3VMuBZCz7L5yViToqjE5zho8W/" defer></script>
 	
 	<!-- Service Worker registration moved to assets/js/security-init.js -->
 	

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Service Worker for Advanced Caching Strategy
-// Version: 2025.12.1
+// Version: 2025.12.2
 
-const CACHE_NAME = 'prajitdas-cache-v2025.12.1';
-const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.1';
-const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.1';
+const CACHE_NAME = 'prajitdas-cache-v2025.12.2';
+const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.2';
+const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.2';
 
 // Critical resources for immediate caching (LCP optimization)
 const CRITICAL_ASSETS = [
@@ -23,7 +23,7 @@ const STATIC_ASSETS = [
   '/assets/js/jquery-3.7.1.min.js?v=2025.11',
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
-  '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/main.js?v=2025.12.2',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
## 🚨 Severity: HIGH

## 💡 Vulnerability
Dynamically created third-party iframes (specifically the YouTube video embed in `assets/js/main.js`) lacked the `sandbox` attribute. While YouTube is a trusted provider, embedding unsandboxed iframes from external domains introduces potential risks, including cross-site scripting (XSS), malicious pop-ups, and unauthorized top-level navigation, particularly if the provider were ever compromised or served malicious ad payloads.

## 🎯 Impact
Without a sandbox, the embedded content has the same privileges as the parent document. An attacker exploiting a vulnerability in the third-party service could potentially execute arbitrary code within the context of the main application, access sensitive data, or hijack the user session. By restricting the iframe's capabilities, we significantly reduce the attack surface.

## 🔧 Fix
1.  **Added `sandbox` Attribute:** Modified `assets/js/main.js` to add the `sandbox` attribute to the dynamically generated YouTube iframe. The applied restrictions (`allow-scripts allow-popups allow-presentation allow-same-origin`) adhere to the principle of least privilege, allowing only the features necessary for the player to function correctly while blocking others. `allow-same-origin` is specifically required for YouTube embeds to work.
2.  **Cache Invalidation:** Incremented the `CACHE_NAME`, `STATIC_CACHE_NAME`, and `DYNAMIC_CACHE_NAME` variables in the Service Worker (`sw.js`) to `v2025.12.2` and updated the corresponding version query strings for `main.js` in both `sw.js` and `index.html`.
3.  **SRI Hash Update:** Recalculated the SHA-384 Subresource Integrity (SRI) hash for the modified `assets/js/main.js` and updated the `integrity` attribute in `index.html` to prevent the browser from blocking the script.
4.  **Sentinel Journal:** Logged the vulnerability, learning, and prevention strategy as a reusable security pattern in `.jules/sentinel.md`.

## ✅ Verification
1.  Verify the updated SRI hash by ensuring `main.js` loads correctly without browser console errors.
2.  Run the validation suite: `python3 .github/code/tests/run_all_validation.py --quick`. All tests pass successfully.
3.  Inspect the DOM after clicking the "Play" button on the 3-Minute Thesis video to confirm the iframe includes the `sandbox="allow-scripts allow-popups allow-presentation allow-same-origin"` attribute and that the video still plays correctly.

---
*PR created automatically by Jules for task [5880007552685334710](https://jules.google.com/task/5880007552685334710) started by @prajitdas*