### PR TITLE
🛡️ Sentinel: [HIGH] Harden CSP by removing unsafe-inline from script-src

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -75,7 +75,7 @@
   Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
   Header always set Referrer-Policy "strict-origin-when-cross-origin"
   Header always set Permissions-Policy "camera=(), microphone=(), geolocation=()"
-  Header always set Content-Security-Policy "default-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; media-src 'self' https:; object-src 'none'; frame-src 'self' https://www.youtube.com https://youtube.com; base-uri 'self'; form-action 'self';"
+  Header always set Content-Security-Policy "default-src 'self' https:; script-src 'self' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; media-src 'self' https:; object-src 'none'; frame-src 'self' https://www.youtube.com https://youtube.com; base-uri 'self'; form-action 'self';"
 </IfModule>
 
 <IfModule mod_gzip.c>

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** The `404.html` page had a weaker Content Security Policy (CSP) allowing `'unsafe-inline'` and lacked the essential security initialization script (`assets/js/security-init.js`) found in `index.html`. This created a potential attack vector if an attacker could lure a user to a non-existent URL.
 **Learning:** Security configurations (CSP, SRI, Headers) must be consistent across all pages, including error pages (404, 500). Error pages are often overlooked during security audits but share the same origin and can be exploited.
 **Prevention:** Treat `404.html` as a first-class citizen in the security architecture. Ensure it imports the same security-hardened scripts and uses the same strict CSP headers as the main application. Verify error pages during security testing.
+
+## 2026-05-06 - [Strict CSP on Secondary Pages]
+**Vulnerability:** The secondary pages (`projects.html`, `publications.html`, `service.html`, `modern.html`, `experience.html`) and the `.htaccess` configuration still allowed `'unsafe-inline'` for `script-src` in their Content Security Policies (CSP). Additionally, `modern.html` contained an inline script for the "Read More" button and email obfuscation, creating potential XSS vectors.
+**Learning:** CSPs must be strict and consistent across all entry points, including secondary pages and server-level configurations (`.htaccess`). Inline scripts must be externalized, and the `script-src` directive should not include `'unsafe-inline'` unless absolutely necessary (which is rarely the case if scripts are properly modularized).
+**Prevention:** Avoid inline scripts entirely. If dynamic script injection is needed, use SRI hashes or nonces. Ensure all HTML files and server configurations share a unified, strict CSP.

--- a/404.html
+++ b/404.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/assets/js/modern.js
+++ b/assets/js/modern.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const btn = document.getElementById('read-more-btn');
+    const moreContent = document.getElementById('about-more');
+
+    if (btn && moreContent) {
+        btn.addEventListener('click', function() {
+            if (moreContent.classList.contains('visible')) {
+                moreContent.classList.remove('visible');
+                btn.innerHTML = 'Read More <i class="fas fa-chevron-down"></i>';
+            } else {
+                moreContent.classList.add('visible');
+                btn.innerHTML = 'Read Less <i class="fas fa-chevron-up"></i>';
+            }
+        });
+    }
+
+    // Email obfuscation
+    const emailLink = document.getElementById('email-link');
+    if (emailLink) {
+        const user = 'prajitdas';
+        const domain = 'gmail.com';
+        emailLink.addEventListener('mouseover', function() {
+            this.href = 'mailto:' + user + '@' + domain;
+        });
+        emailLink.addEventListener('click', function(e) {
+            if (this.getAttribute('href') === '#') {
+                e.preventDefault();
+                window.location.href = 'mailto:' + user + '@' + domain;
+            }
+        });
+    }
+});

--- a/experience.html
+++ b/experience.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/modern.html
+++ b/modern.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->
@@ -136,40 +136,7 @@
             <p>&copy; 2025 Prajit Kumar Das. Hosted on GitHub Pages.</p>
         </div>
     </footer>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const btn = document.getElementById('read-more-btn');
-            const moreContent = document.getElementById('about-more');
-            
-            if (btn && moreContent) {
-                btn.addEventListener('click', function() {
-                    if (moreContent.classList.contains('visible')) {
-                        moreContent.classList.remove('visible');
-                        btn.innerHTML = 'Read More <i class="fas fa-chevron-down"></i>';
-                    } else {
-                        moreContent.classList.add('visible');
-                        btn.innerHTML = 'Read Less <i class="fas fa-chevron-up"></i>';
-                    }
-                });
-            }
-
-            // Email obfuscation
-            const emailLink = document.getElementById('email-link');
-            if (emailLink) {
-                const user = 'prajitdas';
-                const domain = 'gmail.com';
-                emailLink.addEventListener('mouseover', function() {
-                    this.href = 'mailto:' + user + '@' + domain;
-                });
-                emailLink.addEventListener('click', function(e) {
-                    if (this.getAttribute('href') === '#') {
-                        e.preventDefault();
-                        window.location.href = 'mailto:' + user + '@' + domain;
-                    }
-                });
-            }
-        });
-    </script>
     <script src="assets/js/theme-toggle.js"></script>
+    <script src="assets/js/modern.js" defer></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/publications.html
+++ b/publications.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/service.html
+++ b/service.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/sw.js
+++ b/sw.js
@@ -24,6 +24,7 @@ const STATIC_ASSETS = [
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
   '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/modern.js',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Harden CSP by removing unsafe-inline from script-src

🚨 Severity: HIGH
💡 Vulnerability: The Content-Security-Policy (CSP) allowed `'unsafe-inline'` in the `script-src` directive across secondary pages and `.htaccess`, creating potential Cross-Site Scripting (XSS) vectors. Additionally, `modern.html` contained an inline script for interactivity.
🎯 Impact: An attacker who finds an injection flaw could execute arbitrary JavaScript within the context of the user's session.
🔧 Fix: Extracted the inline script from `modern.html` into a new external file (`assets/js/modern.js`), updated all secondary pages to use the new script (without unnecessary SRI), removed `'unsafe-inline'` from the `script-src` directives across all HTML files and `.htaccess` while preserving it for `style-src` to prevent layout breakages, and updated the Service Worker cache.
✅ Verification: Ran `run_all_validation.py` to ensure local integrity, resource accessibility, and content security/privacy tests pass without blocking errors. Verified `content_security_privacy.py` and `vulnerability_assessment.py` for correct CSP configuration.

---
*PR created automatically by Jules for task [7528306571785932767](https://jules.google.com/task/7528306571785932767) started by @prajitdas*