### PR TITLE
🛡️ Sentinel: [HIGH] Restrict third-party iframe privileges

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** The `404.html` page had a weaker Content Security Policy (CSP) allowing `'unsafe-inline'` and lacked the essential security initialization script (`assets/js/security-init.js`) found in `index.html`. This created a potential attack vector if an attacker could lure a user to a non-existent URL.
 **Learning:** Security configurations (CSP, SRI, Headers) must be consistent across all pages, including error pages (404, 500). Error pages are often overlooked during security audits but share the same origin and can be exploited.
 **Prevention:** Treat `404.html` as a first-class citizen in the security architecture. Ensure it imports the same security-hardened scripts and uses the same strict CSP headers as the main application. Verify error pages during security testing.
+
+## 2026-05-18 - [Restrict Third-Party Iframe Privileges]
+**Vulnerability:** The application dynamically generated YouTube iframes in `assets/js/main.js` without restricting privileges using the `sandbox` attribute. This could allow malicious content to perform unwanted actions, such as executing scripts or top-level navigation, if the embedded third-party content was compromised.
+**Learning:** The principle of least privilege should be applied to all third-party embeddings, particularly dynamically generated ones. Using the `sandbox` attribute with specific allowances (like `allow-scripts`, `allow-popups`, `allow-presentation`, and `allow-same-origin` for YouTube) ensures functionality while mitigating the risk of malicious actions.
+**Prevention:** Always include a `sandbox` attribute when embedding third-party content via `<iframe>`, explicitly stating only the permissions necessary for the specific use case.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -215,6 +215,8 @@
                 iframe.allowFullscreen = true;
                 iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
                 iframe.title = '3 Minute Thesis competition video';
+                // 🛡️ Sentinel: Restrict third-party iframe privileges using sandbox
+                iframe.sandbox = 'allow-scripts allow-popups allow-presentation allow-same-origin';
 
                 // Clear container and append iframe
                 while (container.firstChild) {

--- a/index.html
+++ b/index.html
@@ -551,7 +551,7 @@
 	<script src="assets/js/bootstrap.min.js?v=2025.11" integrity="sha384-a5jtiYH5jy2C9nk8lKcS1rJKNol+cJ9NJsVMDkCOm9QKXwm5Rq9bpSzg6zmnr48D" defer></script>
 	<script src="assets/plugins/vegas/jquery.vegas.min.js?v=2025.11" integrity="sha384-coBErv0EgCI7VkSd++JmHxhjwxROUhJ37ZNTnevFBMK4ukZOMTiD+wLfguBX205T" defer></script>
 	<script src="assets/js/security-init.js?v=2025.11" integrity="sha384-pErhzH0PSA1f7EnrS4Dfo0t3Y1SM0VRvnHUjbUXVawqrdVB3kTGmRRcNIUJiXCr/" defer></script>
-	<script src="assets/js/main.js?v=2025.12.1" integrity="sha384-0VRup29DOBxGZBMqfpqmKMPUz0kNRDjDS3Res32dR76CBzyXyt5yAyLGwM3Waz2Q" defer></script>
+	<script src="assets/js/main.js?v=2025.12.2" integrity="sha384-F7k9x9BL/xKZhKrJQplICmZ5VvvbAkwE0y88phCCy4SfUi0Hn6zDcMaykPaKCGhV" defer></script>
 	
 	<!-- Service Worker registration moved to assets/js/security-init.js -->
 	

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Service Worker for Advanced Caching Strategy
-// Version: 2025.12.1
+// Version: 2025.12.2
 
-const CACHE_NAME = 'prajitdas-cache-v2025.12.1';
-const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.1';
-const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.1';
+const CACHE_NAME = 'prajitdas-cache-v2025.12.2';
+const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.2';
+const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.2';
 
 // Critical resources for immediate caching (LCP optimization)
 const CRITICAL_ASSETS = [
@@ -23,7 +23,7 @@ const STATIC_ASSETS = [
   '/assets/js/jquery-3.7.1.min.js?v=2025.11',
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
-  '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/main.js?v=2025.12.2',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Dynamically created YouTube iframes in main.js lacked the sandbox attribute, potentially allowing compromised third-party content to execute malicious actions like top-level navigation.
🎯 Impact: If the embedded content is compromised, it could abuse its unrestricted access to perform actions outside the scope of its intended functionality, affecting user security and experience.
🔧 Fix: Added the sandbox attribute to the dynamically generated iframe with specific allowances (allow-scripts, allow-popups, allow-presentation, allow-same-origin) following the principle of least privilege. Recalculated the SRI hash for main.js and updated cache versionings.
✅ Verification: Ensure the YouTube video still plays correctly and that no errors related to the iframe's permissions appear in the browser console. Tests run via run_all_validation.py and content_security_privacy.py passed.

---
*PR created automatically by Jules for task [6161774534953257101](https://jules.google.com/task/6161774534953257101) started by @prajitdas*