### PR TITLE
🛡️ Sentinel: [HIGH] Eliminate inline scripts and harden CSP

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -75,7 +75,7 @@
   Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
   Header always set Referrer-Policy "strict-origin-when-cross-origin"
   Header always set Permissions-Policy "camera=(), microphone=(), geolocation=()"
-  Header always set Content-Security-Policy "default-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; media-src 'self' https:; object-src 'none'; frame-src 'self' https://www.youtube.com https://youtube.com; base-uri 'self'; form-action 'self';"
+  Header always set Content-Security-Policy "default-src 'self' https:; script-src 'self' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; media-src 'self' https:; object-src 'none'; frame-src 'self' https://www.youtube.com https://youtube.com; base-uri 'self'; form-action 'self';"
 </IfModule>
 
 <IfModule mod_gzip.c>

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** The `404.html` page had a weaker Content Security Policy (CSP) allowing `'unsafe-inline'` and lacked the essential security initialization script (`assets/js/security-init.js`) found in `index.html`. This created a potential attack vector if an attacker could lure a user to a non-existent URL.
 **Learning:** Security configurations (CSP, SRI, Headers) must be consistent across all pages, including error pages (404, 500). Error pages are often overlooked during security audits but share the same origin and can be exploited.
 **Prevention:** Treat `404.html` as a first-class citizen in the security architecture. Ensure it imports the same security-hardened scripts and uses the same strict CSP headers as the main application. Verify error pages during security testing.
+
+## 2025-02-24 - [CSP Hardening on Secondary Pages]
+**Vulnerability:** Secondary HTML pages (like `modern.html`, `projects.html`, etc.) allowed `'unsafe-inline'` in their Content Security Policy (CSP) `script-src` directive, primarily because of a lingering inline script in `modern.html` that handled UI toggling.
+**Learning:** Having a strict CSP on the main page (`index.html`) is insufficient if secondary pages retain weak policies. Attackers will target the weakest link. Furthermore, inline scripts not only degrade security but also clutter HTML and complicate caching strategies.
+**Prevention:** All scripts should be externalized. Global CSP policies (e.g., in `.htaccess`) and page-level policies (via `<meta>` tags) must be kept strictly synced and prohibit `'unsafe-inline'` for scripts across the entire domain.

--- a/404.html
+++ b/404.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/assets/js/modern.js
+++ b/assets/js/modern.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const btn = document.getElementById('read-more-btn');
+    const moreContent = document.getElementById('about-more');
+
+    if (btn && moreContent) {
+        btn.addEventListener('click', function() {
+            if (moreContent.classList.contains('visible')) {
+                moreContent.classList.remove('visible');
+                btn.innerHTML = 'Read More <i class="fas fa-chevron-down"></i>';
+            } else {
+                moreContent.classList.add('visible');
+                btn.innerHTML = 'Read Less <i class="fas fa-chevron-up"></i>';
+            }
+        });
+    }
+
+    // Email obfuscation
+    const emailLink = document.getElementById('email-link');
+    if (emailLink) {
+        const user = 'prajitdas';
+        const domain = 'gmail.com';
+        emailLink.addEventListener('mouseover', function() {
+            this.href = 'mailto:' + user + '@' + domain;
+        });
+        emailLink.addEventListener('click', function(e) {
+            if (this.getAttribute('href') === '#') {
+                e.preventDefault();
+                window.location.href = 'mailto:' + user + '@' + domain;
+            }
+        });
+    }
+});

--- a/experience.html
+++ b/experience.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/modern.html
+++ b/modern.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->
@@ -136,40 +136,7 @@
             <p>&copy; 2025 Prajit Kumar Das. Hosted on GitHub Pages.</p>
         </div>
     </footer>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const btn = document.getElementById('read-more-btn');
-            const moreContent = document.getElementById('about-more');
-            
-            if (btn && moreContent) {
-                btn.addEventListener('click', function() {
-                    if (moreContent.classList.contains('visible')) {
-                        moreContent.classList.remove('visible');
-                        btn.innerHTML = 'Read More <i class="fas fa-chevron-down"></i>';
-                    } else {
-                        moreContent.classList.add('visible');
-                        btn.innerHTML = 'Read Less <i class="fas fa-chevron-up"></i>';
-                    }
-                });
-            }
-
-            // Email obfuscation
-            const emailLink = document.getElementById('email-link');
-            if (emailLink) {
-                const user = 'prajitdas';
-                const domain = 'gmail.com';
-                emailLink.addEventListener('mouseover', function() {
-                    this.href = 'mailto:' + user + '@' + domain;
-                });
-                emailLink.addEventListener('click', function(e) {
-                    if (this.getAttribute('href') === '#') {
-                        e.preventDefault();
-                        window.location.href = 'mailto:' + user + '@' + domain;
-                    }
-                });
-            }
-        });
-    </script>
+    <script src="assets/js/modern.js?v=2025.12.2" integrity="sha384-A1nRQ0dDurrmWxNFAnIGoJLf5Y5FATFwe9LQN0n3kiAeLQED/cEpWkrdaBoEahtq" crossorigin="anonymous"></script>
     <script src="assets/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/publications.html
+++ b/publications.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/service.html
+++ b/service.html
@@ -13,7 +13,7 @@
     <!-- Security Headers -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://prajitdas.github.io; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'self' https://www.youtube.com; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), vr=(), gyroscope=(), accelerometer=(), magnetometer=(), midi=(), sync-xhr=()">
 
     <!-- SEO & Open Graph -->

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,9 @@
 // Service Worker for Advanced Caching Strategy
-// Version: 2025.12.1
+// Version: 2025.12.2
 
-const CACHE_NAME = 'prajitdas-cache-v2025.12.1';
-const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.1';
-const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.1';
+const CACHE_NAME = 'prajitdas-cache-v2025.12.2';
+const STATIC_CACHE_NAME = 'prajitdas-static-v2025.12.2';
+const DYNAMIC_CACHE_NAME = 'prajitdas-dynamic-v2025.12.2';
 
 // Critical resources for immediate caching (LCP optimization)
 const CRITICAL_ASSETS = [
@@ -24,6 +24,7 @@ const STATIC_ASSETS = [
   '/assets/plugins/vegas/jquery.vegas.min.js?v=2025.11',
   '/assets/js/bootstrap.min.js?v=2025.11',
   '/assets/js/main.js?v=2025.12.1',
+  '/assets/js/modern.js?v=2025.12.2',
   '/assets/plugins/vegas/images/loading.gif',
   '/assets/plugins/vegas/overlays/01.png',
   '/assets/plugins/vegas/overlays/15.png',


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Secondary HTML pages (like `modern.html`, `projects.html`, etc.) and the global `.htaccess` file allowed `'unsafe-inline'` in their Content Security Policy (CSP) `script-src` directive, primarily because of a lingering inline script in `modern.html`. This weakened the site's defense against Cross-Site Scripting (XSS) attacks.
🎯 Impact: If an attacker found a way to inject malicious content into any of these secondary pages, the browser would execute it because inline scripts were broadly permitted.
🔧 Fix:
- Extracted the inline script (Read More logic and email obfuscation) from `modern.html` into a new external file `assets/js/modern.js`.
- Updated `modern.html` to load this script securely with Subresource Integrity (SRI).
- Hardened the CSP `<meta>` tags across all secondary HTML pages (`projects.html`, `modern.html`, `404.html`, `experience.html`, `publications.html`, `service.html`) by completely removing `'unsafe-inline'` from `script-src`.
- Updated the `.htaccess` global CSP header similarly, restricting `default-src` and `script-src` to `https:` and `'self'`.
- Updated the Service Worker (`sw.js`) to cache the new `modern.js` file and incremented cache versions.
✅ Verification: Ran the consolidated website validation test suite (`python3 .github/code/tests/run_all_validation.py --quick`). The "Content Security & Privacy" tests passed perfectly, confirming the hardened CSP rules do not conflict with the site's functionality.

---
*PR created automatically by Jules for task [15186131958472489689](https://jules.google.com/task/15186131958472489689) started by @prajitdas*